### PR TITLE
Faster load form

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -39,6 +39,7 @@
                  ;; [org.clojure/clojurescript "1.10.439"]
                  [org.clojure/clojurescript "1.10.520"]
                  [re-frame "0.10.9"]
+                 [day8.re-frame/test "0.1.5" :scope "test"]
                  [reagent-utils "0.3.3"]
                  [org.webjars/font-awesome "5.10.1"]
                  [antizer "0.3.1"]

--- a/src/clj/byf/config.clj
+++ b/src/clj/byf/config.clj
@@ -8,8 +8,8 @@
   []
   (let [profile (:environment env)]
     ;; the dev profile always reloads even `config.edn`
-    (if (or (= :dev profile)
-            (nil? @config))
+    (when (or (= :dev profile)
+              (nil? @config))
       (reset! config (aero/read-config "config.edn" {:profile profile})))
 
     ;; if there is a `user.edn` file load that as well and merge it

--- a/src/cljs/byf/common/views.cljs
+++ b/src/cljs/byf/common/views.cljs
@@ -25,7 +25,8 @@
   []
   (let [error @(rf/subscribe [:failed])]
     (when errors
-      [:div.error "Error = " (str error)])))
+     [ant/alert {:type "error"
+                 :message error}])))
 
 (defn footer
   []

--- a/src/cljs/byf/core.cljs
+++ b/src/cljs/byf/core.cljs
@@ -6,6 +6,7 @@
             [byf.league-detail.handlers :as league-detail-handlers]
             [byf.league-detail.views :as league-detail-views]
             [byf.league-list.handlers :as league-list-handlers]
+            [byf.league-detail.handlers.add-game :as add-handlers]
             [byf.league-list.views :as league-list-views]
             [byf.admin.views :as admin-views]
             [byf.admin.handlers :as admin-handlers]
@@ -64,6 +65,7 @@
 
 (defn ^:export init []
   (re-frame/dispatch-sync [::league-list-handlers/initialize-db])
+  (re-frame/dispatch-sync [::add-handlers/initialize-db])
   (re-frame/dispatch-sync [::league-detail-handlers/initialize-db])
   (re-frame/dispatch-sync [::admin-handlers/initialize-db])
   (re-frame/dispatch-sync [::auth/authenticated?])

--- a/src/cljs/byf/league_detail/add_game.cljs
+++ b/src/cljs/byf/league_detail/add_game.cljs
@@ -6,6 +6,7 @@
             [byf.utils :as utils]
             [byf.common.players :as players-handlers]
             [byf.league-detail.handlers :as handlers]
+            [byf.league-detail.handlers.add-game :as add-handlers]
             [cljsjs.moment]))
 
 (def form-config
@@ -35,9 +36,9 @@
   []
   (rf/dispatch [::players-handlers/load-players])
   (fn []
-    (let [players (rf/subscribe [::players-handlers/active-players-full])
-          valid-game? (rf/subscribe [::handlers/valid-game?])
-          game (rf/subscribe [::handlers/game])
+    (let [players (rf/subscribe [::add-handlers/active-players-full])
+          valid-game? (rf/subscribe [::add-handlers/valid-game?])
+          game (rf/subscribe [::add-handlers/game])
           league (rf/subscribe [::handlers/league])
           game-type (or (:game_type @league) :fifa)
           points-range (map str (config/opts game-type :points))
@@ -45,22 +46,22 @@
 
       [ant/form form-config
        [ant/form-item {:label "Player 1"}
-        [common-views/drop-down-players sorted-players ::handlers/p1 (:p1 @game)]]
+        [common-views/drop-down-players sorted-players ::add-handlers/p1 (:p1 @game)]]
 
        [ant/form-item {:label "Goals"}
-        [common-views/drop-down points-range ::handlers/p1_points (:p1_points @game)]]
+        [common-views/drop-down points-range ::add-handlers/p1_points (:p1_points @game)]]
 
        [ant/form-item {:label "Team 1"}
-        [team-input (:p1_using @game) ::handlers/p1_using]]
+        [team-input (:p1_using @game) ::add-handlers/p1_using]]
 
        [ant/form-item {:label "Player 2"}
-        [common-views/drop-down-players sorted-players ::handlers/p2 (:p2 @game)]]
+        [common-views/drop-down-players sorted-players ::add-handlers/p2 (:p2 @game)]]
 
        [ant/form-item {:label "Goals"}
-        [common-views/drop-down points-range ::handlers/p2_points (:p2_points @game)]]
+        [common-views/drop-down points-range ::add-handlers/p2_points (:p2_points @game)]]
 
        [ant/form-item {:label "Team 2"}
-        [team-input (:p2_using @game) ::handlers/p2_using]]
+        [team-input (:p2_using @game) ::add-handlers/p2_using]]
 
        [ant/form-item {:label "Played At"}
         ;; link to the right value here
@@ -69,11 +70,11 @@
                           :value (:played_at @game)
                           :on-change
                           (fn [mo _]
-                            (rf/dispatch [::handlers/played_at mo]))}]]
+                            (rf/dispatch [::add-handlers/played_at mo]))}]]
 
        [ant/form-item
         [ant/button
          (enable-button @valid-game?
                         {:type "primary"
-                         :on-click #(rf/dispatch [::handlers/add-game])})
+                         :on-click #(rf/dispatch [::add-handlers/add-game])})
          "Add Game"]]])))

--- a/src/cljs/byf/league_detail/add_game.cljs
+++ b/src/cljs/byf/league_detail/add_game.cljs
@@ -33,45 +33,47 @@
 
 (defn game-form
   []
-  (let [players (rf/subscribe [::players-handlers/active-players-full])
-        valid-game? (rf/subscribe [::handlers/valid-game?])
-        game (rf/subscribe [::handlers/game])
-        league (rf/subscribe [::handlers/league])
-        game-type (or (:game_type @league) :fifa)
-        points-range (map str (config/opts game-type :points))
-        sorted-players (sort-by :name @players)]
+  (rf/dispatch [::players-handlers/load-players])
+  (fn []
+    (let [players (rf/subscribe [::players-handlers/active-players-full])
+          valid-game? (rf/subscribe [::handlers/valid-game?])
+          game (rf/subscribe [::handlers/game])
+          league (rf/subscribe [::handlers/league])
+          game-type (or (:game_type @league) :fifa)
+          points-range (map str (config/opts game-type :points))
+          sorted-players (sort-by :name @players)]
 
-    [ant/form form-config
-     [ant/form-item {:label "Player 1"}
-      [common-views/drop-down-players sorted-players ::handlers/p1 (:p1 @game)]]
+      [ant/form form-config
+       [ant/form-item {:label "Player 1"}
+        [common-views/drop-down-players sorted-players ::handlers/p1 (:p1 @game)]]
 
-     [ant/form-item {:label "Goals"}
-      [common-views/drop-down points-range ::handlers/p1_points (:p1_points @game)]]
+       [ant/form-item {:label "Goals"}
+        [common-views/drop-down points-range ::handlers/p1_points (:p1_points @game)]]
 
-     [ant/form-item {:label "Team 1"}
-      [team-input (:p1_using @game) ::handlers/p1_using]]
+       [ant/form-item {:label "Team 1"}
+        [team-input (:p1_using @game) ::handlers/p1_using]]
 
-     [ant/form-item {:label "Player 2"}
-      [common-views/drop-down-players sorted-players ::handlers/p2 (:p2 @game)]]
+       [ant/form-item {:label "Player 2"}
+        [common-views/drop-down-players sorted-players ::handlers/p2 (:p2 @game)]]
 
-     [ant/form-item {:label "Goals"}
-      [common-views/drop-down points-range ::handlers/p2_points (:p2_points @game)]]
+       [ant/form-item {:label "Goals"}
+        [common-views/drop-down points-range ::handlers/p2_points (:p2_points @game)]]
 
-     [ant/form-item {:label "Team 2"}
-      [team-input (:p2_using @game) ::handlers/p2_using]]
+       [ant/form-item {:label "Team 2"}
+        [team-input (:p2_using @game) ::handlers/p2_using]]
 
-     [ant/form-item {:label "Played At"}
-      ;; link to the right value here
-      [ant/date-picker {:show-time true
-                        :format "YYYY-MM-DD HH:mm"
-                        :value (:played_at @game)
-                        :on-change
-                        (fn [mo _]
-                          (rf/dispatch [::handlers/played_at mo]))}]]
+       [ant/form-item {:label "Played At"}
+        ;; link to the right value here
+        [ant/date-picker {:show-time true
+                          :format "YYYY-MM-DD HH:mm"
+                          :value (:played_at @game)
+                          :on-change
+                          (fn [mo _]
+                            (rf/dispatch [::handlers/played_at mo]))}]]
 
-     [ant/form-item
-      [ant/button
-       (enable-button @valid-game?
-                      {:type "primary"
-                       :on-click #(rf/dispatch [::handlers/add-game])})
-       "Add Game"]]]))
+       [ant/form-item
+        [ant/button
+         (enable-button @valid-game?
+                        {:type "primary"
+                         :on-click #(rf/dispatch [::handlers/add-game])})
+         "Add Game"]]])))

--- a/src/cljs/byf/league_detail/desktop.cljs
+++ b/src/cljs/byf/league_detail/desktop.cljs
@@ -57,7 +57,6 @@
 (defn results
   []
   (rf/dispatch [::handlers/load-games])
-
   (let [show-results (rf/subscribe [::handlers/show-results])]
     (fn []
       [:div.inner
@@ -132,6 +131,7 @@
 
   (let [loading? @(rf/subscribe [::handlers/loading?])
         errors @(rf/subscribe [:failed])]
+
     [:div.root
      [navbar]
 

--- a/src/cljs/byf/league_detail/desktop.cljs
+++ b/src/cljs/byf/league_detail/desktop.cljs
@@ -57,6 +57,7 @@
 (defn results
   []
   (rf/dispatch [::handlers/load-games])
+
   (let [show-results (rf/subscribe [::handlers/show-results])]
     (fn []
       [:div.inner
@@ -140,8 +141,6 @@
         (if loading?
           [ant/spin {:size "large"}]
           [:div.content
-           #_[ant/card
-              [set-current-user]]
            [current-user-notification]
            [:div {:id "add-game"}
             [game-form]]

--- a/src/cljs/byf/league_detail/desktop.cljs
+++ b/src/cljs/byf/league_detail/desktop.cljs
@@ -56,6 +56,7 @@
 
 (defn results
   []
+  (rf/dispatch [::handlers/load-games])
   (let [show-results (rf/subscribe [::handlers/show-results])]
     (fn []
       [:div.inner
@@ -126,7 +127,6 @@
   []
   ;; this is kind of an antipattern for reframe
   (rf/dispatch [::handlers/load-league])
-  (rf/dispatch [::handlers/load-games])
   (rf/dispatch [::players-handlers/load-players])
 
   (let [loading? @(rf/subscribe [::handlers/loading?])

--- a/src/cljs/byf/league_detail/desktop.cljs
+++ b/src/cljs/byf/league_detail/desktop.cljs
@@ -128,6 +128,7 @@
   ;; this is kind of an antipattern for reframe
   (rf/dispatch [::handlers/load-league])
   (rf/dispatch [::players-handlers/load-players])
+  (rf/dispatch [::handlers/load-games])
 
   (let [loading? @(rf/subscribe [::handlers/loading?])
         errors @(rf/subscribe [:failed])]

--- a/src/cljs/byf/league_detail/handlers/add_game.cljs
+++ b/src/cljs/byf/league_detail/handlers/add_game.cljs
@@ -1,0 +1,105 @@
+(ns byf.league-detail.handlers.add-game
+  (:require [re-frame.core :as rf]
+            [byf.common.players :as players-handlers]
+            [byf.common.handlers :as common]
+            [byf.shared-config :as shared]))
+
+(def default-game
+  {:p1 ""
+   :p2 ""
+   :p1_points ""
+   :p2_points ""
+   :p1_using ""
+   :p2_using ""
+   :played_at (js/moment)})
+
+(def page ::page-id)
+
+(rf/reg-event-db ::reset-game
+                 (fn [db _]
+                   (common/assoc-in* db page [:game] default-game)))
+
+(def setter (partial common/setter* page))
+
+(def getter (partial common/getter* page))
+
+(rf/reg-event-db ::p1 (setter [:game :p1]))
+(rf/reg-event-db ::p1_points (setter [:game :p1_points]))
+(rf/reg-event-db ::p1_using (setter [:game :p1_using]))
+
+(rf/reg-event-db ::p2 (setter [:game :p2]))
+(rf/reg-event-db ::p2_points (setter [:game :p2_points]))
+(rf/reg-event-db ::p2_using (setter [:game :p2_using]))
+(rf/reg-event-db ::played_at (setter [:game :played_at]))
+
+(rf/reg-sub ::game (getter [:game]))
+
+(defn valid-players?
+  [{:keys [p1 p2]}]
+  (not= p1 p2))
+
+;; I could return some kind of coeffect when there is an error
+;; to give a better warning in the UI
+(defn valid-result?
+  [game-type game]
+  (let [p1 (:p1_points game)
+        p2 (:p2_points game)
+        draw? (-> shared/games-config :fifa :draw?)]
+
+    (or draw?
+        (not= p1 p2))))
+
+
+(rf/reg-sub ::players
+            (constantly ["one" "two" "three"]))
+
+(rf/reg-sub ::valid-players?
+            :<- [::game]
+
+            (fn [game _]
+              (valid-players? game)))
+
+(rf/reg-sub ::valid-result?
+            :<- [::game]
+            :<- [::game-type]
+
+            (fn [[game-type game] _]
+              (valid-result? game-type game)))
+
+(rf/reg-sub ::filled-game?
+            (fn [db _]
+              (not-any? #(= % "")
+                        (vals (common/get-in* db page [:game])))))
+
+
+(rf/reg-sub ::valid-game?
+            :<- [::valid-result?]
+            :<- [::filled-game?]
+            :<- [::valid-players?]
+
+            (fn [[valid-result? filled-game? valid-players?] _]
+              (and valid-result?
+                   filled-game?
+                   valid-players?)))
+
+(defn- reload-fn-gen
+  [extra-signal]
+  (fn [{:keys [db]} _]
+    {:db db
+     :dispatch-n (cons extra-signal [[::add-user-notification]
+                                     [::players-handlers/load-players]
+                                     [::load-games]])}))
+
+(rf/reg-event-fx ::add-game-success (reload-fn-gen [::reset-game]))
+
+(defn game-params
+  [db]
+  (update
+   (common/get-in* db page [:game])
+   :played_at
+   #(.format % shared/timestamp-format)))
+
+(rf/reg-event-fx ::add-game
+                 (common/writer "/api/add-game"
+                                ::add-game-success
+                                game-params))

--- a/src/cljs/byf/league_detail/handlers/add_game.cljs
+++ b/src/cljs/byf/league_detail/handlers/add_game.cljs
@@ -49,7 +49,6 @@
     (or draw?
         (not= p1 p2))))
 
-
 (rf/reg-sub ::players
             (constantly ["one" "two" "three"]))
 
@@ -70,7 +69,6 @@
             (fn [db _]
               (not-any? #(= % "")
                         (vals (common/get-in* db page [:game])))))
-
 
 (rf/reg-sub ::valid-game?
             :<- [::valid-result?]

--- a/src/cljs/byf/league_detail/handlers/add_game.cljs
+++ b/src/cljs/byf/league_detail/handlers/add_game.cljs
@@ -15,9 +15,9 @@
 
 (def page ::page-id)
 
-(rf/reg-event-db ::reset-game
+(rf/reg-event-db ::initialize-db
                  (fn [db _]
-                   (common/assoc-in* db page [:game] default-game)))
+                   (assoc db page default-game)))
 
 (def setter (partial common/setter* page))
 
@@ -32,7 +32,7 @@
 (rf/reg-event-db ::p2_using (setter [:game :p2_using]))
 (rf/reg-event-db ::played_at (setter [:game :played_at]))
 
-(rf/reg-sub ::game (getter [:game]))
+(rf/reg-sub ::game (fn [db _] db))
 
 (defn valid-players?
   [{:keys [p1 p2]}]
@@ -90,7 +90,7 @@
                                      [::players-handlers/load-players]
                                      [::load-games]])}))
 
-(rf/reg-event-fx ::add-game-success (reload-fn-gen [::reset-game]))
+(rf/reg-event-fx ::add-game-success (reload-fn-gen [::initialize-db]))
 
 (defn game-params
   [db]

--- a/test/cljs/byf/league_detail/add_game_test.cljs
+++ b/test/cljs/byf/league_detail/add_game_test.cljs
@@ -1,0 +1,5 @@
+(ns byf.league-detail.add-game-test
+  (:require [byf.league-detail.add-game :as sut]
+            [day8.re-frame.test :as rf-test]
+            [re-frame.core :as rf]
+            [cljs.test :refer-macros [deftest is testing]]))


### PR DESCRIPTION
To load the new game form we don't need all the information about the historical games and the rankings computation, so it can be loaded straight away, while all the rest of the data loads.