### PR TITLE
hide dead

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,4 +27,6 @@ db-graph:
 
 
 test:
-	lein test
+	lein kaocha
+
+.PHONY: test

--- a/api.rest
+++ b/api.rest
@@ -1,7 +1,7 @@
 :local = http://localhost:3335
 :staging = http://fifa-elo-staging.herokuapp.com
 :prod = http://fifa-elo.herokuapp.com
-:league_id = 781c6c09-6dd8-4bf3-8647-225f1f542967
+:league_id = 92a057b3-0ddd-42c9-9474-0969be0c2ced
 
 # check if the resources work
 GET :local/css/screen.css

--- a/api.rest
+++ b/api.rest
@@ -1,7 +1,7 @@
 :local = http://localhost:3335
 :staging = http://fifa-elo-staging.herokuapp.com
 :prod = http://fifa-elo.herokuapp.com
-:league_id = 92a057b3-0ddd-42c9-9474-0969be0c2ced
+:league_id = f631b983-4de2-4be8-a1cf-2a630df3e2da
 
 # check if the resources work
 GET :local/css/screen.css
@@ -11,6 +11,9 @@ GET :local/js/compiled/app.js
 
 # fetch players
 GET :local/api/players?league_id=:league_id
+
+# disable one of the players
+POST :local/api/toggle-player?league_id=:league_id&player_id=f823ffe6-0238-40c7-bbf3-9abdaee45946&active=false
 
 # fetch all the leagues
 GET :local/api/leagues

--- a/src/clj/byf/api.clj
+++ b/src/clj/byf/api.clj
@@ -43,13 +43,6 @@
   [m]
   (medley/map-vals str m))
 
-(defn convert
-  [m]
-  (cond
-    (map? m) (uuid-to-str m)
-    (sequential? m) (map uuid-to-str m)
-    :else m))
-
 (defn- as-edn
   [response]
   (-> response
@@ -122,6 +115,13 @@
       :league_id
       validate/to-uuid))
 
+(defn- get-player-id
+  [request]
+  (-> request
+      :params
+      :player_id
+      validate/to-uuid))
+
 (defn get-players
   [request]
   (-> (get-league-id request)
@@ -184,12 +184,14 @@
 
 (defn toggle-player!
   [request]
-  (let [{:keys [league_id player_id enabled]} (:params request)]
-    (db/toggle-player! league_id player_id enabled)
+  (let [league-id (get-league-id request)
+        player-id (get-player-id request)
+        enabled (-> request :params :enabled)]
+    (db/toggle-player! league-id player-id enabled)
     (resp/ok
-     {:player-id player_id
+     {:player-id player-id
       :enabled   enabled
-      :league_id league_id})))
+      :league_id league-id})))
 
 ;;TODO: add a not found page for everything else?
 (def routes

--- a/src/clj/byf/api.clj
+++ b/src/clj/byf/api.clj
@@ -2,7 +2,6 @@
   (:gen-class)
   (:require [clojure.java.jdbc :as jdbc]
             [clojure.data.json :as json]
-            [clj-time.format :as cf]
             [bidi.ring :refer [make-handler]]
             [buddy.auth.middleware :refer [wrap-authentication wrap-authorization]]
             [clojure.string :as str]
@@ -183,10 +182,20 @@
                          (some? github-token))
       :token github-token})))
 
+(defn toggle-player!
+  [request]
+  (let [{:keys [league_id player_id enabled]} (:params request)]
+    (db/toggle-player! league_id player_id enabled)
+    (resp/ok
+     {:player-id player_id
+      :enabled   enabled
+      :leauge_id league_id})))
+
 ;;TODO: add a not found page for everything else?
 (def routes
   ["/" {"api/" {"add-player" add-player!
                 "add-game" add-game!
+                "toggle-player" toggle-player!
 
                 "league" get-league
                 "leagues" get-leagues

--- a/src/clj/byf/api.clj
+++ b/src/clj/byf/api.clj
@@ -186,11 +186,12 @@
   [request]
   (let [league-id (get-league-id request)
         player-id (get-player-id request)
-        enabled (-> request :params :enabled)]
-    (db/toggle-player! league-id player-id enabled)
-    (resp/ok
+        active    (-> request :params :active)]
+    (db/toggle-player! league-id player-id active)
+    (resp/created
+     "api/players"
      {:player-id player-id
-      :enabled   enabled
+      :active    active
       :league_id league-id})))
 
 ;;TODO: add a not found page for everything else?

--- a/src/clj/byf/api.clj
+++ b/src/clj/byf/api.clj
@@ -189,7 +189,7 @@
     (resp/ok
      {:player-id player_id
       :enabled   enabled
-      :leauge_id league_id})))
+      :league_id league_id})))
 
 ;;TODO: add a not found page for everything else?
 (def routes

--- a/src/clj/byf/api.clj
+++ b/src/clj/byf/api.clj
@@ -186,7 +186,8 @@
   [request]
   (let [league-id (get-league-id request)
         player-id (get-player-id request)
-        active    (-> request :params :active)]
+        active_str (-> request :params :active)
+        active (if (= "true" active_str) true false)]
     (db/toggle-player! league-id player-id active)
     (resp/created
      "api/players"

--- a/src/clj/byf/db.clj
+++ b/src/clj/byf/db.clj
@@ -176,11 +176,12 @@
    (h/where
     [:and
      [:= :player_id player-id]
-     [:= :leauge_id league-id]])))
+     [:= :league_id league-id]])))
 
 (defn toggle-player!
   [league-id player-id enabled]
   (jdbc/execute! (db-spec)
-                 (toggle-player-sql league-id
-                                    player-id
-                                    enabled)))
+                 (sql/format
+                  (toggle-player-sql league-id
+                                     player-id
+                                     enabled))))

--- a/src/clj/byf/db.clj
+++ b/src/clj/byf/db.clj
@@ -169,19 +169,19 @@
       (h/where [:= :id player-id])))
 
 (defn toggle-player-sql
-  [league-id player-id enabled]
+  [league-id player-id active]
   (->
    (h/update :league-players)
-   (h/sset {:enabled enabled})
+   (h/sset {:active active})
    (h/where
     [:and
      [:= :player_id player-id]
      [:= :league_id league-id]])))
 
 (defn toggle-player!
-  [league-id player-id enabled]
+  [league-id player-id active]
   (jdbc/execute! (db-spec)
                  (sql/format
                   (toggle-player-sql league-id
                                      player-id
-                                     enabled))))
+                                     active))))

--- a/src/clj/byf/db.clj
+++ b/src/clj/byf/db.clj
@@ -167,3 +167,20 @@
   (-> (h/select :name)
       (h/from :player)
       (h/where [:= :id player-id])))
+
+(defn toggle-player-sql
+  [league-id player-id enabled]
+  (->
+   (h/update :league-players)
+   (h/sset {:enabled enabled})
+   (h/where
+    [:and
+     [:= :player_id player-id]
+     [:= :leauge_id league-id]])))
+
+(defn toggle-player!
+  [league-id player-id enabled]
+  (jdbc/execute! (db-spec)
+                 (toggle-player-sql league-id
+                                    player-id
+                                    enabled)))

--- a/src/clj/byf/db.clj
+++ b/src/clj/byf/db.clj
@@ -42,7 +42,7 @@
 
 (defn load-players-sql
   [league-id]
-  (-> (h/select :*)
+  (-> (h/select :pl.id :pl.email :pl.name :lg.active)
       (h/from [:player :pl])
       (h/join [:league_players :lg]
               [:= :pl.id :lg.player_id])

--- a/src/cljs/byf/common/players.cljs
+++ b/src/cljs/byf/common/players.cljs
@@ -22,6 +22,13 @@
                    (map :id)
                    set)))
 
+(rf/reg-sub ::active-players-full
+            :<- [::players]
+
+            (fn [players]
+              (->> players
+                   (filter :active))))
+
 (rf/reg-sub ::name-mapping
             :<- [::players]
 

--- a/src/cljs/byf/league_detail/add_game.cljs
+++ b/src/cljs/byf/league_detail/add_game.cljs
@@ -33,7 +33,7 @@
 
 (defn game-form
   []
-  (let [players (rf/subscribe [::players-handlers/players])
+  (let [players (rf/subscribe [::players-handlers/active-players-full])
         valid-game? (rf/subscribe [::handlers/valid-game?])
         game (rf/subscribe [::handlers/game])
         league (rf/subscribe [::handlers/league])

--- a/test/clj/byf/api_test.clj
+++ b/test/clj/byf/api_test.clj
@@ -147,8 +147,13 @@
 (deftest enable-player-test
   (testing "Enabling a player or disabling it"
     (let [response (write-api-call "/toggle-player" {:league_id sample-league-id
-                                                     :player-id 100})]
-      (is (= 200 (:status response))))))
+                                                     :player-id 100})
+          with-disabled (read-api-call "/api/players" {:league_id sample-league-id})]
+      (is (= 200 (:status response)))
+      ;; now fetch the players
+      (is (= 200 (:status with-disabled)))
+      (is (= [] (:body with-disabled)))
+      )))
 
 (deftest auth-test
   (testing "Should be able to check if a user is already authenticated"

--- a/test/clj/byf/api_test.clj
+++ b/test/clj/byf/api_test.clj
@@ -144,6 +144,12 @@
                  json/read-str
                  (get "id")))))))
 
+(deftest enable-player-test
+  (testing "Enabling a player or disabling it"
+    (let [response (write-api-call "/toggle-player" {:league_id sample-league-id
+                                                     :player-id 100})]
+      (is (= 200 (:status response))))))
+
 (deftest auth-test
   (testing "Should be able to check if a user is already authenticated"
     (let [response (read-api-call "/authenticated")]

--- a/test/clj/byf/api_test.clj
+++ b/test/clj/byf/api_test.clj
@@ -115,7 +115,12 @@
           body-obj (json/read-str (:body response))]
       (is (= 200 (:status response)))
       (is (= 1 (count body-obj)))
-      (is (true? (-> body-obj first (get "active")))))))
+      (is (= {"email" nil,
+              "name" "john",
+              "active" true}
+             (-> body-obj
+                 first
+                 (dissoc "id")))))))
 
 (deftest add-player-user-test
   (with-redefs [env (assoc env :admin-password "admin-password")]

--- a/test/clj/byf/api_test.clj
+++ b/test/clj/byf/api_test.clj
@@ -58,7 +58,9 @@
             authenticated-req
             sut/app)]
 
-    (assert (contains? #{201 401} status), "Invalid status code")
+    (when-not (contains? #{201 401} status)
+      (println "bad response, got " response)
+      (throw (Exception. "bad response, should be #{201, 401}")))
     response))
 
 (defn- store-users!
@@ -143,13 +145,13 @@
              (-> (:body response)
                  json/read-str
                  (get "id")))))))
-
 (deftest enable-player-test
   (testing "Enabling a player or disabling it"
-    (let [response (write-api-call "/toggle-player" {:league_id sample-league-id
-                                                     :player-id 100})
+    (let [[p1-id p2-id] (store-users!)
+          _response (write-api-call "/toggle-player" {:league_id sample-league-id
+                                                      :player-id p1-id})
+          
           with-disabled (read-api-call "/api/players" {:league_id sample-league-id})]
-      (is (= 200 (:status response)))
       ;; now fetch the players
       (is (= 200 (:status with-disabled)))
       (is (= [] (:body with-disabled)))

--- a/test/clj/byf/api_test.clj
+++ b/test/clj/byf/api_test.clj
@@ -150,17 +150,22 @@
              (-> (:body response)
                  json/read-str
                  (get "id")))))))
+
 (deftest enable-player-test
   (testing "Enabling a player or disabling it"
-    (let [[p1-id p2-id] (store-users!)
-          _response (write-api-call "/toggle-player" {:league_id sample-league-id
-                                                      :player-id p1-id})
+    (let [[p1-id _] (store-users!)
+          _response     (write-api-call "/toggle-player" {:league_id sample-league-id
+                                                          :player_id (:player-id p1-id)
+                                                          :active    false})
           
-          with-disabled (read-api-call "/api/players" {:league_id sample-league-id})]
+          with-disabled (read-api-call "/api/players" {:league_id sample-league-id})
+          with-disabled-first-user (-> with-disabled
+                                       :body
+                                       json/read-str
+                                       first)]
       ;; now fetch the players
       (is (= 200 (:status with-disabled)))
-      (is (= [] (:body with-disabled)))
-      )))
+      (is (false? (get with-disabled-first-user "active"))))))
 
 (deftest auth-test
   (testing "Should be able to check if a user is already authenticated"

--- a/test/clj/byf/api_test.clj
+++ b/test/clj/byf/api_test.clj
@@ -157,7 +157,7 @@
           _response     (write-api-call "/toggle-player" {:league_id sample-league-id
                                                           :player_id (:player-id p1-id)
                                                           :active    false})
-          
+
           with-disabled (read-api-call "/api/players" {:league_id sample-league-id})
           with-disabled-first-user (-> with-disabled
                                        :body


### PR DESCRIPTION
Allow to hide players from the admin UI/API and make sure they don't show up in the list of available players.